### PR TITLE
Update version to 4.5.2 to match base image version

### DIFF
--- a/instances/MUG/pom.xml
+++ b/instances/MUG/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>at.medunigraz</groupId>
   <artifactId>damap-be</artifactId>
-  <version>0.5.0-beta</version>
+  <version>4.5.2</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
   <description>A tool for machine actionable DMPs.</description>

--- a/instances/TUG/pom.xml
+++ b/instances/TUG/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>at.tugraz</groupId>
   <artifactId>damap</artifactId>
-  <version>4.3.0</version>
+  <version>4.5.2</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
   <description>A tool for machine actionable DMPs.</description>


### PR DESCRIPTION
for only:
  TUG,
  MUG
  
  _Testing options:_ docker build --build-arg INSTANCE_NAME=TUG -t damap-backend-tug:4.5.2 . 
  _equivalent to:_ 
  _instance:_ docker build --build-arg INSTANCE_NAME=TUG -t damap-backend-tug .