### PR TITLE
feat: implement version management with parent POM

### DIFF
--- a/.github/workflows/instances.yml
+++ b/.github/workflows/instances.yml
@@ -24,13 +24,22 @@ on:
           - TUG
           - MUG
           - JKU
+          - all
         required: false
-        default: 'TUG'
+        default: 'all'
+      base_version:
+        description: 'DAMAP base version to use'
+        required: false
+        default: ''
+      release_tag:
+        description: 'Release tag for all images'
+        required: false
+        default: ''
 
 jobs:
   build-backend-mug:
     runs-on: ubuntu-22.04
-    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.instance == 'both' || github.event.inputs.instance == 'MUG' }}
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.instance == 'all' || github.event.inputs.instance == 'MUG' }}
     permissions:
       contents: read
       packages: write
@@ -41,18 +50,45 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
 
+      - name: Set up Java and Maven
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Copy Maven settings for Docker
+        run: |
+          mkdir -p .m2
+          cp ~/.m2/settings.xml .m2/settings.xml
+
       - name: Convert repository name to lowercase
         run: echo "IMAGE_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Determine Docker tag (from tag or branch)
         id: get_tag
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ "${{ github.event.inputs.release_tag }}" != "" ]]; then
+            TAG_NAME="${{ github.event.inputs.release_tag }}"
+          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
             TAG_NAME="${GITHUB_REF#refs/tags/}"
           else
             TAG_NAME="${GITHUB_REF#refs/heads/}"
           fi
           echo "DOCKER_TAG=$TAG_NAME" >> $GITHUB_ENV
+
+      - name: Set up build arguments
+        run: |
+          BUILD_ARGS="INSTANCE_NAME=MUG"
+          if [[ "${{ github.event.inputs.base_version }}" != "" ]]; then
+            BUILD_ARGS="$BUILD_ARGS\nDAMAP_BASE_VERSION=${{ github.event.inputs.base_version }}"
+          fi
+          echo "BUILD_ARGS<<EOF" >> $GITHUB_ENV
+          echo -e "$BUILD_ARGS" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
@@ -72,15 +108,14 @@ jobs:
         with:
           context: .
           push: true
-          build-args: |
-            INSTANCE_NAME=MUG
+          build-args: ${{ env.BUILD_ARGS }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DOCKER_TAG }}-mug
           labels: ${{ steps.meta.outputs.labels }}
 
   build-backend-tug:
     runs-on: ubuntu-22.04
-    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.instance == 'both' || github.event.inputs.instance == 'TUG' }}
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.instance == 'all' || github.event.inputs.instance == 'TUG' }}
     permissions:
       contents: read
       packages: write
@@ -91,18 +126,45 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
 
+      - name: Set up Java and Maven
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Copy Maven settings for Docker
+        run: |
+          mkdir -p .m2
+          cp ~/.m2/settings.xml .m2/settings.xml
+
       - name: Convert repository name to lowercase
         run: echo "IMAGE_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Determine Docker tag (from tag or branch)
         id: get_tag
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ "${{ github.event.inputs.release_tag }}" != "" ]]; then
+            TAG_NAME="${{ github.event.inputs.release_tag }}"
+          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
             TAG_NAME="${GITHUB_REF#refs/tags/}"
           else
             TAG_NAME="${GITHUB_REF#refs/heads/}"
           fi
           echo "DOCKER_TAG=$TAG_NAME" >> $GITHUB_ENV
+
+      - name: Set up build arguments
+        run: |
+          BUILD_ARGS="INSTANCE_NAME=TUG"
+          if [[ "${{ github.event.inputs.base_version }}" != "" ]]; then
+            BUILD_ARGS="$BUILD_ARGS\nDAMAP_BASE_VERSION=${{ github.event.inputs.base_version }}"
+          fi
+          echo "BUILD_ARGS<<EOF" >> $GITHUB_ENV
+          echo -e "$BUILD_ARGS" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
@@ -122,15 +184,14 @@ jobs:
         with:
           context: .
           push: true
-          build-args: |
-            INSTANCE_NAME=TUG
+          build-args: ${{ env.BUILD_ARGS }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DOCKER_TAG }}-tug
           labels: ${{ steps.meta.outputs.labels }}
 
   build-backend-jku:
     runs-on: ubuntu-22.04
-    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.instance == 'both' || github.event.inputs.instance == 'JKU' }}
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.instance == 'all' || github.event.inputs.instance == 'JKU' }}
     permissions:
       contents: read
       packages: write
@@ -141,18 +202,45 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
 
+      - name: Set up Java and Maven
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Copy Maven settings for Docker
+        run: |
+          mkdir -p .m2
+          cp ~/.m2/settings.xml .m2/settings.xml
+
       - name: Convert repository name to lowercase
         run: echo "IMAGE_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Determine Docker tag (from tag or branch)
         id: get_tag
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ "${{ github.event.inputs.release_tag }}" != "" ]]; then
+            TAG_NAME="${{ github.event.inputs.release_tag }}"
+          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
             TAG_NAME="${GITHUB_REF#refs/tags/}"
           else
             TAG_NAME="${GITHUB_REF#refs/heads/}"
           fi
           echo "DOCKER_TAG=$TAG_NAME" >> $GITHUB_ENV
+
+      - name: Set up build arguments
+        run: |
+          BUILD_ARGS="INSTANCE_NAME=JKU"
+          if [[ "${{ github.event.inputs.base_version }}" != "" ]]; then
+            BUILD_ARGS="$BUILD_ARGS\nDAMAP_BASE_VERSION=${{ github.event.inputs.base_version }}"
+          fi
+          echo "BUILD_ARGS<<EOF" >> $GITHUB_ENV
+          echo -e "$BUILD_ARGS" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
@@ -172,8 +260,7 @@ jobs:
         with:
           context: .
           push: true
-          build-args: |
-            INSTANCE_NAME=JKU
+          build-args: ${{ env.BUILD_ARGS }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DOCKER_TAG }}-jku
           labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+instances/*/target/

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ This directory contains documentation for managing and deploying DAMAP instances
 | Guide | Description |
 |-------|-------------|
 | [Development Setup](DEVELOPMENT.md) | Local development environment |
+| [Versions](VERSIONS.md) | Instance version and CI/CD |
 | [Custom Integrations](INTEGRATIONS.md) | Adding institution-specific APIs |
 | [Testing Guide](TESTING.md) | Running tests and validation |
 
@@ -29,4 +30,5 @@ This directory contains documentation for managing and deploying DAMAP instances
 
 | Guide | Description |
 |-------|-------------|
+| [Versions](VERSIONS.md) | Instance version strategy and CI/CD |
 | [Changelog](../CHANGELOG.md) | Version history and changes |

--- a/docs/VERSIONS.md
+++ b/docs/VERSIONS.md
@@ -1,0 +1,102 @@
+# DAMAP Instance Version Management
+
+This describes the version management system for DAMAP instances (TUG, MUG, JKU, etc.).
+
+## Overview
+
+We use a **Parent POM approach** combined with **CI/CD flexibility** to manage `damap-base` versions across all instances.
+
+## Architecture
+
+### Parent POM (`pom.xml`)
+- **Central version management** for `damap-base` dependency
+- **Instance-specific defaults**:
+  - **TUG**: `0.0.0-SNAPSHOT` (follows upstream development)
+  - **MUG**: `4.5.2` (stable version)
+  - **JKU**: `4.4.0` (stable version)
+- **Profiles** for different scenarios:
+  - `use-latest-release`: Uses stable released version (4.6.1)
+  - `production`: Production-ready version
+
+### Instance POMs (TUG, MUG, JKU)
+- **Inherit** from parent POM
+- **Can override** base version if needed
+- **Keep their own identity** (groupId, artifactId)
+
+### CI/CD Pipeline
+- **Supports version override** via build arguments
+- **Unified release tagging** for all instances
+- **Flexible instance selection** (individual or all)
+
+## Usage scenarios
+
+### Default Behavior (Instance-specific)
+```bash
+# TUG uses SNAPSHOT, MUG uses 4.5.2, JKU uses 4.4.0
+mvn clean package
+```
+
+### Use Latest Release
+```bash
+# Uses stable release version
+mvn clean package -Puse-latest-release
+```
+
+### Override Version in CI/CD
+```bash
+# Specify custom version
+mvn clean package -Ddamap.base.version=4.7.0
+```
+
+### Override in Child POM
+```xml
+<!-- In instances/TUG/pom.xml -->
+<properties>
+  <damap.base.version>4.7.0</damap.base.version>
+</properties>
+```
+
+## CI/CD Features
+
+### Manual Workflow Dispatch Options
+
+1. **Instance Selection**:
+   - `TUG` - Build only TUG
+   - `MUG` - Build only MUG  
+   - `JKU` - Build only JKU
+   - `all` - Build all instances
+
+2. **Base Version Override**:
+   - Leave empty: Use parent POM default
+   - Specify version: Override for this build (e.g., `4.7.0`)
+
+3. **Release Tagging**:
+   - Leave empty: Use branch/tag name
+   - Specify tag: Tag all images with same version (e.g., `latest`, `v4.7.0`)
+
+### Example Workflows
+
+#### Development Build
+```yaml
+# Uses SNAPSHOT version from parent POM
+- Trigger: Push to main
+- Result: Images tagged with "main"
+```
+
+#### Testing New Base Version
+```yaml
+# Manual dispatch with custom base version
+- Instance: "all"
+- Base Version: "4.7.0"
+- Release Tag: "test-4.7.0"
+- Result: All images built with base 4.7.0, tagged as "test-4.7.0"
+```
+
+#### Official Release
+```yaml
+# Manual dispatch for official release
+- Instance: "all"
+- Base Version: "4.6.1" (stable)
+- Release Tag: "latest"
+- Result: All images built with stable base, tagged as "latest"
+```

--- a/instances/JKU/pom.xml
+++ b/instances/JKU/pom.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-  xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
+  <!-- inherit from parent POM -->
+  <parent>
+    <groupId>org.damap</groupId>
+    <artifactId>damap-instances-parent</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
 
   <groupId>at.jku</groupId>
   <artifactId>damap</artifactId>
@@ -21,40 +28,22 @@
   </licenses>
 
   <properties>
+    <damap.base.version>${damap.base.version.jku}</damap.base.version>
+    
     <surefire-plugin.version>3.2.3</surefire-plugin.version>
-    <maven.compiler.target>17</maven.compiler.target>
-    <maven.compiler.source>17</maven.compiler.source>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.parameters>true</maven.compiler.parameters>
     <compiler-plugin.version>3.12.1</compiler-plugin.version>
-    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.11.1</quarkus.platform.version>
     <spotless.version>2.44.0.BETA1</spotless.version>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>${quarkus.platform.group-id}</groupId>
-        <artifactId>${quarkus.platform.artifact-id}</artifactId>
-        <version>${quarkus.platform.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
-    <!-- Base image -->
+    <!-- Base image - version managed by parent -->
     <dependency>
       <groupId>org.damap</groupId>
       <artifactId>base</artifactId>
-      <version>4.4.0</version>
     </dependency>
-    <!-- Test -->
-  <dependency>
+    
+    <!-- Test dependencies -->
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jacoco</artifactId>
       <scope>test</scope>
@@ -94,11 +83,12 @@
       <artifactId>quarkus-jdbc-h2</artifactId>
       <scope>test</scope>
     </dependency>
+    
+    <!-- Rest dependencies -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-validator</artifactId>
     </dependency>
-    <!-- Rest -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-rest</artifactId>
@@ -119,6 +109,7 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-rest-client-jackson</artifactId>
     </dependency>
+    
     <!-- Authentication -->
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -128,6 +119,7 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-jwt</artifactId>
     </dependency>
+    
     <!-- Database -->
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -153,11 +145,13 @@
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
     </dependency>
+    
     <!-- Health -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-health</artifactId>
     </dependency>
+    
     <!-- Utility -->
     <dependency>
       <groupId>org.reflections</groupId>
@@ -167,7 +161,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.24</version>
+      <version>1.18.30</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -197,9 +191,22 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>${quarkus.platform.group-id}</groupId>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.7.0</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs-verify</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${quarkus.platform.version}</version>
         <extensions>true</extensions>
         <executions>
           <execution>
@@ -211,7 +218,7 @@
           </execution>
         </executions>
       </plugin>
-     <plugin>
+      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${compiler-plugin.version}</version>
         <configuration>
@@ -229,29 +236,20 @@
         </configuration>
       </plugin>
       <plugin>
-        <!--These
-        are plugins which we do not nessesary need it: 
-            maven-compiler-plugin: 
-           org.codehaus.mojo: generates java classes which we use from base (xsd)
-          maven-deploy-plugin: we do not call deploy in any pipelin 
-        jsonschema2pojo-maven-plugin: generates java classes which we use from base (json) -->
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
         <version>${spotless.version}</version>
         <configuration>
           <java>
-            <!-- These are the defaults, you can override if you want -->
             <includes>
               <include>src/main/java/**/*.java</include>
               <include>src/test/java/**/*.java</include>
             </includes>
-            <!-- Cleanthat will refactor your code, but it may break your style: apply it before
-            your formatter -->
             <cleanthat />
             <googleJavaFormat></googleJavaFormat>
-            <importOrder /> <!-- standard import order -->
-            <removeUnusedImports /> <!-- self-explanatory -->
-            <formatAnnotations />  <!-- fixes formatting of type annotations -->
+            <importOrder />
+            <removeUnusedImports />
+            <formatAnnotations />
           </java>
         </configuration>
         <executions>
@@ -268,9 +266,22 @@
         <artifactId>liquibase-maven-plugin</artifactId>
         <version>4.28.0</version>
       </plugin>
+      <plugin>
+        <groupId>io.smallrye</groupId>
+        <artifactId>jandex-maven-plugin</artifactId>
+        <version>3.1.8</version>
+        <executions>
+          <execution>
+            <id>make-index</id>
+            <goals>
+              <goal>jandex</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
-    <!-- jandex-maven-plugin: generates indexes of exported classes of the base-->
   </build>
+
   <profiles>
     <profile>
       <id>native</id>
@@ -309,7 +320,5 @@
         <quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
       </properties>
     </profile>
-    <!-- sonar: usecase: if you call maven with this profile, sonarsource we be used: 
-             deploy-mvn-repository: is used only for dep of the base -->
   </profiles>
 </project>

--- a/instances/MUG/pom.xml
+++ b/instances/MUG/pom.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-  xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
+  <!-- Inherit from parent POM -->
+  <parent>
+    <groupId>org.damap</groupId>
+    <artifactId>damap-instances-parent</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
 
   <groupId>at.medunigraz</groupId>
   <artifactId>damap-be</artifactId>
@@ -21,40 +28,22 @@
   </licenses>
 
   <properties>
-   <surefire-plugin.version>3.2.3</surefire-plugin.version>
-    <maven.compiler.target>17</maven.compiler.target>
-    <maven.compiler.source>17</maven.compiler.source>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.parameters>true</maven.compiler.parameters>
+    <damap.base.version>${damap.base.version.mug}</damap.base.version>
+    
+    <surefire-plugin.version>3.2.3</surefire-plugin.version>
     <compiler-plugin.version>3.12.1</compiler-plugin.version>
-    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.11.1</quarkus.platform.version>
     <spotless.version>2.44.0.BETA1</spotless.version>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>${quarkus.platform.group-id}</groupId>
-        <artifactId>${quarkus.platform.artifact-id}</artifactId>
-        <version>${quarkus.platform.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
- <dependencies>
-    <!-- Base image -->
+  <dependencies>
+    <!-- Base image - version managed by parent -->
     <dependency>
       <groupId>org.damap</groupId>
       <artifactId>base</artifactId>
-      <version>4.5.2</version>
     </dependency>
-    <!-- Test -->
-   <dependency>
+    
+    <!-- Test dependencies -->
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jacoco</artifactId>
       <scope>test</scope>
@@ -94,11 +83,12 @@
       <artifactId>quarkus-jdbc-h2</artifactId>
       <scope>test</scope>
     </dependency>
+    
+    <!-- Rest dependencies -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-validator</artifactId>
     </dependency>
-    <!-- Rest -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-rest</artifactId>
@@ -119,6 +109,7 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-rest-client-jackson</artifactId>
     </dependency>
+    
     <!-- Authentication -->
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -128,6 +119,7 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-jwt</artifactId>
     </dependency>
+    
     <!-- Database -->
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -153,11 +145,13 @@
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
     </dependency>
+    
     <!-- Health -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-health</artifactId>
     </dependency>
+    
     <!-- Utility -->
     <dependency>
       <groupId>org.reflections</groupId>
@@ -197,9 +191,22 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>${quarkus.platform.group-id}</groupId>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.7.0</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs-verify</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${quarkus.platform.version}</version>
         <extensions>true</extensions>
         <executions>
           <execution>
@@ -211,7 +218,7 @@
           </execution>
         </executions>
       </plugin>
-     <plugin>
+      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${compiler-plugin.version}</version>
         <configuration>
@@ -229,30 +236,20 @@
         </configuration>
       </plugin>
       <plugin>
-        <!--
-        These are plugins which we do not nessesary need it: 
-        maven-compiler-plugin: org.codehaus.mojo: generates java classes which we use from base (xsd)
-        maven-deploy-plugin: we do not call deploy in any pipelin jsonschema2pojo-maven-plugin: generates java classes which we use from base (json) 
-        -->
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
         <version>${spotless.version}</version>
         <configuration>
           <java>
-            <!-- These are the defaults, you can override if you want -->
             <includes>
               <include>src/main/java/**/*.java</include>
               <include>src/test/java/**/*.java</include>
             </includes>
-            <!-- 
-            Cleanthat will refactor your code, but it may break your style: apply it before
-            your formatter 
-            -->
             <cleanthat />
             <googleJavaFormat></googleJavaFormat>
-            <importOrder /> <!-- standard import order -->
-            <removeUnusedImports /> <!-- self-explanatory -->
-            <formatAnnotations />  <!-- fixes formatting of type annotations -->
+            <importOrder />
+            <removeUnusedImports />
+            <formatAnnotations />
           </java>
         </configuration>
         <executions>
@@ -269,9 +266,22 @@
         <artifactId>liquibase-maven-plugin</artifactId>
         <version>4.28.0</version>
       </plugin>
+      <plugin>
+        <groupId>io.smallrye</groupId>
+        <artifactId>jandex-maven-plugin</artifactId>
+        <version>3.1.8</version>
+        <executions>
+          <execution>
+            <id>make-index</id>
+            <goals>
+              <goal>jandex</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
-    <!-- jandex-maven-plugin: generates indexes of exported classes of the base-->
   </build>
+
   <profiles>
     <profile>
       <id>native</id>
@@ -310,9 +320,5 @@
         <quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
       </properties>
     </profile>
-    <!-- 
-    sonar: usecase: if you call maven with this profile, sonarsource we be used: 
-    deploy-mvn-repository: is used only for dep of the base 
-    -->
   </profiles>
 </project>

--- a/instances/TUG/pom.xml
+++ b/instances/TUG/pom.xml
@@ -1,10 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-  xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <!-- Inherit from parent POM -->
+  <parent>
+    <groupId>org.damap</groupId>
+    <artifactId>damap-instances-parent</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <!-- TUG-specific identity -->
   <groupId>at.tugraz</groupId>
   <artifactId>damap</artifactId>
   <version>4.6.1</version>
@@ -21,55 +29,23 @@
   </licenses>
 
   <properties>
+    <!-- TUG uses SNAPSHOT to get latest updates -->
+    <damap.base.version>${damap.base.version.tug}</damap.base.version>
+    
+    <!-- TUG-specific properties -->
     <surefire-plugin.version>3.2.3</surefire-plugin.version>
-    <maven.compiler.target>17</maven.compiler.target>
-    <maven.compiler.source>17</maven.compiler.source>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.parameters>true</maven.compiler.parameters>
     <compiler-plugin.version>3.12.1</compiler-plugin.version>
-    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.11.1</quarkus.platform.version>
     <spotless.version>2.44.0.BETA1</spotless.version>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>github</id>
-      <name>GitHub Packages</name>
-      <url>https://maven.pkg.github.com/damap-org/damap-backend</url>
-    </repository>
-  </repositories>
-
-  <distributionManagement>
-    <repository>
-      <id>github</id>
-      <name>CSD Github</name>
-      <url>https://maven.pkg.github.com/damap-org/damap-backend</url>
-    </repository>
-  </distributionManagement>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>${quarkus.platform.group-id}</groupId>
-        <artifactId>${quarkus.platform.artifact-id}</artifactId>
-        <version>${quarkus.platform.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
-    <!-- Base image -->
+    <!-- Base image - version managed by parent -->
     <dependency>
       <groupId>org.damap</groupId>
       <artifactId>base</artifactId>
-      <version>0.0.0-SNAPSHOT</version>
     </dependency>
-    <!-- Test -->
+    
+    <!-- Test dependencies -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jacoco</artifactId>
@@ -110,11 +86,12 @@
       <artifactId>quarkus-jdbc-h2</artifactId>
       <scope>test</scope>
     </dependency>
+    
+    <!-- Rest dependencies -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-validator</artifactId>
     </dependency>
-    <!-- Rest -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-rest</artifactId>
@@ -135,6 +112,7 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-rest-client-jackson</artifactId>
     </dependency>
+    
     <!-- Authentication -->
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -144,6 +122,7 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-jwt</artifactId>
     </dependency>
+    
     <!-- Database -->
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -169,11 +148,13 @@
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
     </dependency>
+    
     <!-- Health -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-health</artifactId>
     </dependency>
+    
     <!-- Utility -->
     <dependency>
       <groupId>org.reflections</groupId>
@@ -227,9 +208,8 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>${quarkus.platform.group-id}</groupId>
+        <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${quarkus.platform.version}</version>
         <extensions>true</extensions>
         <executions>
           <execution>
@@ -241,7 +221,7 @@
           </execution>
         </executions>
       </plugin>
-     <plugin>
+      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${compiler-plugin.version}</version>
         <configuration>
@@ -259,85 +239,20 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>jaxb2-maven-plugin</artifactId>
-        <version>3.2.0</version>
-        <executions>
-          <execution>
-            <id>xjc</id>
-            <phase>none</phase>
-            <goals>
-              <goal>xjc</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <skip>true</skip>
-          <sources>
-            <source>src/main/resources/org/damap/base/spec/fits/fits_output.xsd</source>
-            <source>src/main/resources/org/damap/base/spec/re3data/re3dataV3-0.xsd</source>
-            <source>src/main/resources/org/damap/base/spec/re3data/re3dataV2-2.xsd</source>
-            <source>src/main/resources/org/damap/base/spec/re3data/re3data_index_V1-0.xsd</source>
-            <source>src/main/resources/org/damap/base/spec/oaf/oaf-response-1.0.xsd</source>
-          </sources>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.1.2</version>
-        <executions>
-          <execution>
-            <id>default-deploy</id>
-            <phase>deploy</phase>
-            <goals>
-              <goal>deploy</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-        <version>1.1.1</version>
-        <configuration>
-          <skip>true</skip>
-          <annotationStyle>jackson</annotationStyle>
-          <sourceDirectory>${basedir}/src/main/resources/org/damap/base/schema</sourceDirectory>
-          <targetPackage>org.damap.base.rest.madmp.dto</targetPackage>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>none</phase>
-            <goals>
-              <goal>generate</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <!--These
-        are plugins which we do not nessesary need it: 
-            maven-compiler-plugin: 
-           org.codehaus.mojo: generates java classes which we use from base (xsd)
-          maven-deploy-plugin: we do not call deploy in any pipelin 
-        jsonschema2pojo-maven-plugin: generates java classes which we use from base (json) -->
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
         <version>${spotless.version}</version>
         <configuration>
           <java>
-            <!-- These are the defaults, you can override if you want -->
             <includes>
               <include>src/main/java/**/*.java</include>
               <include>src/test/java/**/*.java</include>
             </includes>
-            <!-- Cleanthat will refactor your code, but it may break your style: apply it before
-            your formatter -->
             <cleanthat />
             <googleJavaFormat></googleJavaFormat>
-            <importOrder /> <!-- standard import order -->
-            <removeUnusedImports /> <!-- self-explanatory -->
-            <formatAnnotations />  <!-- fixes formatting of type annotations -->
+            <importOrder />
+            <removeUnusedImports />
+            <formatAnnotations />
           </java>
         </configuration>
         <executions>
@@ -354,9 +269,6 @@
         <artifactId>liquibase-maven-plugin</artifactId>
         <version>4.28.0</version>
       </plugin>
-      <!-- Index resources for this package. When setting this package as a dependency, it will automatically
-      register all beans and resources and the endpoints are available.
-      -->
       <plugin>
         <groupId>io.smallrye</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
@@ -371,8 +283,8 @@
         </executions>
       </plugin>
     </plugins>
-    <!-- jandex-maven-plugin: generates indexes of exported classes of the base-->
   </build>
+
   <profiles>
     <profile>
       <id>native</id>
@@ -411,67 +323,5 @@
         <quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
       </properties>
     </profile>
-    <profile>
-      <id>deploy-mvn-repository</id>
-      <build>
-        <plugins>
-          <!-- Generate <package>-sources.jar for deployment -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-source-plugin</artifactId>
-            <version>3.3.1</version>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>jar-no-fork</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <!-- Generate <package>-javadoc.jar for deployment -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.7.0</version>
-            <executions>
-              <execution>
-                <id>attach-javadocs</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.4</version>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.sonatype.central</groupId>
-            <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.8.0</version>
-            <extensions>true</extensions>
-            <configuration>
-              <publishingServerId>central</publishingServerId>
-              <autoPublish>true</autoPublish>
-              <waitUntil>published</waitUntil>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <!-- sonar: usecase: if you call maven with this profile, sonarsource we be used: 
-             deploy-mvn-repository: is used only for dep of the base -->
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.damap</groupId>
+  <artifactId>damap-instances-parent</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+
+  <name>DAMAP Instances Parent</name>
+  <description>Parent POM for all DAMAP instance projects (TUG, MUG, JKU, etc.)</description>
+
+  <properties>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    
+    <!-- Default base version - can be overridden in child POMs or via -D property -->
+    <damap.base.version>0.0.0-SNAPSHOT</damap.base.version>
+    
+    <!-- Instance-specific stable versions -->
+    <damap.base.version.tug>0.0.0-SNAPSHOT</damap.base.version.tug>
+    <damap.base.version.mug>4.5.2</damap.base.version.mug>
+    <damap.base.version.jku>4.4.0</damap.base.version.jku>
+    
+    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+    <quarkus.platform.version>3.11.1</quarkus.platform.version>
+    <maven.compiler.parameters>true</maven.compiler.parameters>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/damap-org/damap-backend</url>
+    </repository>
+  </repositories>
+
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/damap-org/damap-backend</url>
+    </repository>
+  </distributionManagement>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- Quarkus BOM -->
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-bom</artifactId>
+        <version>${quarkus.platform.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      
+      <!-- DAMAP Base - central version management -->
+      <dependency>
+        <groupId>org.damap</groupId>
+        <artifactId>base</artifactId>
+        <version>${damap.base.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-maven-plugin</artifactId>
+          <version>${quarkus.platform.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.12.1</version>
+          <configuration>
+            <parameters>${maven.compiler.parameters}</parameters>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.2.3</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <modules>
+    <module>instances/TUG</module>
+    <module>instances/MUG</module>
+    <module>instances/JKU</module>
+  </modules>
+
+  <profiles>
+    <!-- Profile to use latest released version instead of SNAPSHOT -->
+    <profile>
+      <id>use-latest-release</id>
+      <properties>
+        <damap.base.version>4.6.1</damap.base.version>
+      </properties>
+    </profile>
+
+    <!-- Profile for production builds -->
+    <profile>
+      <id>production</id>
+      <properties>
+        <damap.base.version>4.6.1</damap.base.version>
+      </properties>
+    </profile>
+  </profiles>
+</project> 


### PR DESCRIPTION
parent POM (e.g., damap-parent)
the parent POM will define the damap-base version as a property.
all instance projects (TUG, MUG, JKU, etc.) will inherit from this parent.

steps:
update the parent POM with the new damap-base version.
trigger builds for all instances.
tag all images with the same official release version (e.g., v4.6.1).