### PR TITLE
feat: migrate MUG to DAMAP base version 4.6.1

### DIFF
--- a/instances/MUG/pom.xml
+++ b/instances/MUG/pom.xml
@@ -14,7 +14,7 @@
 
   <groupId>at.medunigraz</groupId>
   <artifactId>damap-be</artifactId>
-  <version>4.5.2</version>
+  <version>4.6.1</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
   <description>A tool for machine actionable DMPs.</description>

--- a/instances/MUG/src/main/resources/application.yaml
+++ b/instances/MUG/src/main/resources/application.yaml
@@ -30,7 +30,7 @@ damap:
       class-name: 'at.medunigraz.damap.rest.persons.MUGPersonServiceImpl'
     - display-text: 'ORCID'
       query-value: 'ORCID'
-      class-name: 'org.damap.base.rest.persons.orcid.ORCIDPersonServiceImpl'
+      class-name: 'org.damap.base.integration.orcid.ORCIDPersonServiceImpl'
   
   mug:
     api:

--- a/instances/MUG/src/test/java/at/medunigraz/damap/rest/PersonResourceTest.java
+++ b/instances/MUG/src/test/java/at/medunigraz/damap/rest/PersonResourceTest.java
@@ -17,8 +17,8 @@ import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import java.util.List;
+import org.damap.base.integration.orcid.ORCIDPersonServiceImpl;
 import org.damap.base.rest.PersonResource;
-import org.damap.base.rest.persons.orcid.ORCIDPersonServiceImpl;
 import org.damap.base.security.SecurityService;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.BeforeEach;
@@ -66,6 +66,6 @@ class PersonResourceTest {
 
     verify(mockPersonRestService, times(1))
         .search(anyString(), anyInt(), anyInt(), nullable(List.class));
-    verify(orcidPersonServiceImpl, times(0)).search(any());
+    verify(orcidPersonServiceImpl, times(0)).search(any(org.damap.base.rest.base.Search.class));
   }
 }


### PR DESCRIPTION
Updated MUG Version to 4.6.1

Fixed ORCID Service Configuration MUG Configuration (damap-instance/instances/MUG/src/main/resources/application.yaml):
Fixed the ORCID service class name from org.damap.base.rest.persons.orcid.ORCIDPersonServiceImpl to org.damap.base.integration.orcid.ORCIDPersonServiceImpl

Fixed Test Compilation Issue test File (damap-instance/instances/MUG/src/test/java/at/medunigraz/damap/rest/PersonResourceTest.java):
