### PR TITLE
 Migrate JKU instance to v4.7.0 and improve CI selective builds

### DIFF
--- a/.github/workflows/instances.yml
+++ b/.github/workflows/instances.yml
@@ -37,9 +37,36 @@ on:
         default: ''
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-24.04
+    outputs:
+      mug: ${{ steps.filter.outputs.mug }}
+      tug: ${{ steps.filter.outputs.tug }}
+      jku: ${{ steps.filter.outputs.jku }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref }}
+
+      - name: Detect changed instances
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            mug:
+              - 'instances/MUG/**'
+            tug:
+              - 'instances/TUG/**'
+            jku:
+              - 'instances/JKU/**'
+
   build-backend-mug:
-    runs-on: ubuntu-22.04
-    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.instance == 'all' || github.event.inputs.instance == 'MUG' }}
+    needs: detect-changes
+    runs-on: ubuntu-24.04
+    if: |
+      (github.event_name == 'push' && needs.detect-changes.outputs.mug == 'true') ||
+      (github.event_name == 'workflow_dispatch' && (github.event.inputs.instance == 'all' || github.event.inputs.instance == 'MUG'))
     permissions:
       contents: read
       packages: write
@@ -53,7 +80,7 @@ jobs:
       - name: Convert repository name to lowercase
         run: echo "IMAGE_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
-      - name: Determine Docker tag (from tag or branch)
+      - name: Determine Docker tag
         id: get_tag
         run: |
           if [[ "${{ github.event.inputs.release_tag }}" != "" ]]; then
@@ -100,8 +127,11 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   build-backend-tug:
-    runs-on: ubuntu-22.04
-    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.instance == 'all' || github.event.inputs.instance == 'TUG' }}
+    needs: detect-changes
+    runs-on: ubuntu-24.04
+    if: |
+      (github.event_name == 'push' && needs.detect-changes.outputs.tug == 'true') ||
+      (github.event_name == 'workflow_dispatch' && (github.event.inputs.instance == 'all' || github.event.inputs.instance == 'TUG'))
     permissions:
       contents: read
       packages: write
@@ -115,7 +145,7 @@ jobs:
       - name: Convert repository name to lowercase
         run: echo "IMAGE_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
-      - name: Determine Docker tag (from tag or branch)
+      - name: Determine Docker tag
         id: get_tag
         run: |
           if [[ "${{ github.event.inputs.release_tag }}" != "" ]]; then
@@ -162,8 +192,11 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   build-backend-jku:
-    runs-on: ubuntu-22.04
-    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.instance == 'all' || github.event.inputs.instance == 'JKU' }}
+    needs: detect-changes
+    runs-on: ubuntu-24.04
+    if: |
+      (github.event_name == 'push' && needs.detect-changes.outputs.jku == 'true') ||
+      (github.event_name == 'workflow_dispatch' && (github.event.inputs.instance == 'all' || github.event.inputs.instance == 'JKU'))
     permissions:
       contents: read
       packages: write
@@ -177,7 +210,7 @@ jobs:
       - name: Convert repository name to lowercase
         run: echo "IMAGE_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
-      - name: Determine Docker tag (from tag or branch)
+      - name: Determine Docker tag
         id: get_tag
         run: |
           if [[ "${{ github.event.inputs.release_tag }}" != "" ]]; then

--- a/instances/JKU/jku-local-test/docker-compose.yml
+++ b/instances/JKU/jku-local-test/docker-compose.yml
@@ -1,10 +1,6 @@
 services:
   damap-be:
-    build:
-      context: ../damap-instance
-      dockerfile: Dockerfile
-      args:
-        INSTANCE_NAME: JKU
+    image: ghcr.io/sharedrdm/damap-instance:4.7.0-jku
     restart: unless-stopped
     ports:
       - "8080:8080"
@@ -23,6 +19,14 @@ services:
       DAMAP_FITS_URL: http://fits-service:8080/fits
       DAMAP_GOTENBERG_URL: http://gotenberg:3000
       DAMAP_TITLE: "JKU Demo instance"
+
+  damap-fe:
+    image: ghcr.io/sharedrdm/damap-frontend-jku:4.7.0
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    depends_on:
+      - damap-be
 
   damap-db:
     image: postgres:16


### PR DESCRIPTION
 Migrates JKU instance to v4.7.0 and updates the CI workflow to only build the instance whose files changed, tagging images with the version from pom.xml. 
 
 What did i wanted to achieve here: 
 
 
<img width="971" height="357" alt="Screenshot 2026-04-30 at 10 45 21" src="https://github.com/user-attachments/assets/8e33ccef-97e6-43a8-8afd-2529dee7696d" />
<img width="1452" height="848" alt="Screenshot 2026-04-30 at 10 41 05" src="https://github.com/user-attachments/assets/ad5db874-fafa-4465-a566-70e181083f0d" />
